### PR TITLE
feat: establish absolute imports as mandatory standard

### DIFF
--- a/PYGON.md
+++ b/PYGON.md
@@ -184,6 +184,34 @@ def create_task(title: str) -> tuple[Task | None, str | None]:
 "file_io_error: cannot read file"
 ```
 
+### importの方針統一
+**必須要件**: すべてのimport文は絶対importを使用する。相対importは使用しない。
+
+```python
+# ✅ 推奨: 絶対import
+from src.types.result_types import Result, ValidationResult
+from src.services.user_service import create_user
+from src.models.user import User
+from src.validators.email_validator import validate_email
+
+# ❌ 非推奨: 相対import（ドット付き）
+from ..types.result_types import Result, ValidationResult
+from .user_service import create_user
+from ...models.user import User
+
+# ❌ 非推奨: 相対import（ドットなし）
+from types.result_types import Result, ValidationResult
+from services.user_service import create_user
+from models.user import User
+```
+
+**理由**: 
+- 生成AIツールでのimportエラー防止
+- プロジェクト構造の明確化
+- ファイル移動時のimport維持
+- チーム開発での一貫性向上
+- デバッグ時の依存関係把握の容易さ
+
 ### コメントの言語統一
 **必須要件**: ソースコード内のすべてのコメントは英語で記述する。
 

--- a/TODO.md
+++ b/TODO.md
@@ -67,6 +67,11 @@
   - [x] Implemented backward compatibility with legacy string errors
   - [x] Updated examples to demonstrate rich vs legacy patterns
   - [x] Enhanced PYGON.md documentation with rich error patterns
+- [x] **Established absolute import policy (Issue #16)**
+  - [x] Added comprehensive import policy section to PYGON.md
+  - [x] Defined absolute imports as mandatory standard
+  - [x] Fixed existing relative import in src/types/__init__.py
+  - [x] Documented benefits for AI collaboration and code consistency
 
 ## 🐛 Bugs
 

--- a/src/types/__init__.py
+++ b/src/types/__init__.py
@@ -8,7 +8,7 @@ MultipleErrorResult (multiple errors).
 Makes error conditions explicit, eliminates inconsistency, provides clear function contracts.
 """
 
-from .result_types import Result, ErrorResult, ValidationResult, MultipleErrorResult
+from src.types.result_types import Result, ErrorResult, ValidationResult, MultipleErrorResult
 
 __all__ = [
     "Result",


### PR DESCRIPTION
Add comprehensive import policy to prevent AI coding errors

## Summary
- Added import policy section to PYGON.md establishing absolute imports as mandatory
- Fixed existing relative import in src/types/__init__.py
- Updated TODO.md with completed task

## Benefits
- Prevents AI coding import errors shown in issue #16
- Improves code clarity and project structure understanding
- Ensures consistency across team development

Resolves #16

Generated with [Claude Code](https://claude.ai/code)