### PR TITLE
Add types module conflict avoidance policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ This project is designed for **human-AI collaborative development**:
 - [ ] English comments only
 - [ ] Tests cover both success and error cases
 - [ ] Error messages provide actionable debugging information
+- [ ] **Types module imports**: Use absolute imports (`from src.types.result_types import Result`) to avoid conflicts with Python's standard `types` module
 
 ## 🔧 Configuration
 

--- a/TODO.md
+++ b/TODO.md
@@ -72,6 +72,12 @@
   - [x] Defined absolute imports as mandatory standard
   - [x] Fixed existing relative import in src/types/__init__.py
   - [x] Documented benefits for AI collaboration and code consistency
+- [x] **Defined types module conflict avoidance policy (Issue #18)**
+  - [x] Added comprehensive "typesモジュール競合回避方針" section to PYGON.md
+  - [x] Established clear guidelines for using src/types/ vs Python's standard types module
+  - [x] Created implementation examples and code review checklist
+  - [x] Updated README.md code review checklist with types module import requirements
+  - [x] Documented AI tool collaboration considerations for types module usage
 
 ## 🐛 Bugs
 


### PR DESCRIPTION
Establish comprehensive guidelines to prevent conflicts between Pygon project's src/types/ module and Python's standard types module.

Resolves #18

Generated with [Claude Code](https://claude.ai/code)